### PR TITLE
fix crash

### DIFF
--- a/src/zx.c
+++ b/src/zx.c
@@ -308,8 +308,7 @@ typedef struct zxinfo {
 } zxinfo;
 
 void add_win_list(i3ipcCon *win, zxinfo *info) {
-  gchar *win_name;
-  g_object_get(win, "name", &win_name, NULL);
+  const gchar *win_name = i3ipc_con_get_name(win);
 
   gint id;
   g_object_get(win, "id", &id, NULL);


### PR DESCRIPTION
Fixes #1

From my limited understanding, the crash was being caused by glib not extracting window names from i3ipc-glib correctly on x64 systems. This changes the way the name is obtained by going through i3ipc instead of using glib to extract the GObject attributes from the i3ipcCon.